### PR TITLE
feat: caching blockstore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@web3-storage/multistream-select": "^1.0.1",
         "bytes": "^3.1.2",
         "cf-libp2p-ws-transport": "^1.1.0",
-        "dagula": "^2.0.6",
+        "dagula": "^3.0.0",
         "ipfs-core": "^0.15.4",
         "libp2p": "^0.37.3",
         "magic-bytes.js": "^1.0.12",
@@ -3512,9 +3512,9 @@
       }
     },
     "node_modules/dagula": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/dagula/-/dagula-2.1.2.tgz",
-      "integrity": "sha512-BA7MM+usk7p4NkqATxUmlDXafEcRycrhIZixZ2U9dK80hA9YNfEkxYPsOXR4dInTxnbBEVpMN0sRbaTYulEweA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dagula/-/dagula-3.0.0.tgz",
+      "integrity": "sha512-Kckmsp4alN4fQi4w6xqZ6lYXryWF0/5TtZBnlQVn8FCA29JEMfPWE7Uv64Xj9pXSX27ckJ0EXIAuIHmwT+VdTA==",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^7.0.1",
         "@ipld/car": "^4.1.3",
@@ -14444,9 +14444,9 @@
       }
     },
     "dagula": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/dagula/-/dagula-2.1.2.tgz",
-      "integrity": "sha512-BA7MM+usk7p4NkqATxUmlDXafEcRycrhIZixZ2U9dK80hA9YNfEkxYPsOXR4dInTxnbBEVpMN0sRbaTYulEweA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dagula/-/dagula-3.0.0.tgz",
+      "integrity": "sha512-Kckmsp4alN4fQi4w6xqZ6lYXryWF0/5TtZBnlQVn8FCA29JEMfPWE7Uv64Xj9pXSX27ckJ0EXIAuIHmwT+VdTA==",
       "requires": {
         "@chainsafe/libp2p-noise": "^7.0.1",
         "@ipld/car": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@web3-storage/multistream-select": "^1.0.1",
     "bytes": "^3.1.2",
     "cf-libp2p-ws-transport": "^1.1.0",
-    "dagula": "^2.0.6",
+    "dagula": "^3.0.0",
     "ipfs-core": "^0.15.4",
     "libp2p": "^0.37.3",
     "magic-bytes.js": "^1.0.12",

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -149,10 +149,10 @@ export function createWithTimeoutController (timeout) {
  * @type {Middleware}
  */
 export function withDagula (handler) {
-  return (request, env, ctx) => {
+  return async (request, env, ctx) => {
     const { libp2p } = ctx
     if (!libp2p) throw new Error('missing libp2p host')
-    ctx.dagula = new Dagula(libp2p, env.REMOTE_PEER)
+    ctx.dagula = await Dagula.fromNetwork(libp2p, { peer: env.REMOTE_PEER })
     return handler(request, env, ctx)
   }
 }


### PR DESCRIPTION
This PR updates Dagula to use a blockstore that first checks CF's edge cache for blocks.